### PR TITLE
Support multiple output formats and improve file naming

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3397,6 +3397,7 @@ name = "showmaker"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,4 +25,5 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1"
 base64 = "0.22.1"
+regex = "1"
 

--- a/src/main.js
+++ b/src/main.js
@@ -51,12 +51,17 @@ window.addEventListener("DOMContentLoaded", () => {
         const [fileName, base64] = await invoke("download_rendered_html", {
           htmlPath: lastHtmlPath,
         });
+        console.log("htmlPath: ", lastHtmlPath);
         console.log("[다운로드] fileName:", fileName);
         console.log("[다운로드] base64 length:", base64 ? base64.length : 0);
-        let saveName = lastMdName
-          ? lastMdName.replace(/\.[^.]+$/, "")
-          : "output";
-        saveName = saveName + ".html";
+        console.log("lastMdname: ", lastMdName);
+
+        // fileName's extension
+        let ext = fileName.split(".").pop();
+        console.log("ext: ", ext);
+
+        let saveName = fileName;
+        console.log("saveName: ", saveName);
 
         // Tauri 네이티브 파일 저장 대화상자 사용
         try {


### PR DESCRIPTION
Added 'regex' dependency and logic to clean up output file names by removing trailing timestamps. Updated validation to allow 'revealjs', 'pptx', and 'beamer' formats. Enhanced output file detection to support HTML, PDF, and PPTX files. Improved file save dialog to handle extensions correctly and updated frontend to use the returned file name and extension.